### PR TITLE
Pin bokeh package to version 0.12.6

### DIFF
--- a/notebooks/pixiedust-traffic-analysis.ipynb
+++ b/notebooks/pixiedust-traffic-analysis.ipynb
@@ -49,9 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# We install the prerequisites using the `!pip install` syntax here.\n",
@@ -64,9 +62,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -u bokeh==0.12.6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Before, you can use the PixieDust library it must be imported into the notebook.\n",
@@ -86,9 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# With PixieDust, you can easily load CSV data from a URL into a PySpark DataFrame in the notebook.\n",
@@ -130,19 +133,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "pixiedust": {
      "displayParams": {
       "aggregation": "COUNT",
       "clusterby": "Resolution",
-      "handlerId": "dataframe",
+      "handlerId": "barChart",
       "keyFields": "PdDistrict",
       "mpld3": "false",
       "rendererId": "bokeh",
       "rowCount": "1000",
       "valueFields": "IncidntNum"
      }
-    }
+    },
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -225,7 +228,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "pixiedust": {
      "displayParams": {
       "aggregation": "COUNT",
@@ -293,7 +295,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "pixiedust": {
      "displayParams": {
       "aggregation": "COUNT",
@@ -386,7 +387,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "pixiedust": {
      "displayParams": {
       "targetDivId": "dialog0a8ccdefroot"


### PR DESCRIPTION
The bokeh version 0.12.7 breaks functionality in PixieDust, so pin
to version 0.12.6.

Closes: #26