### PR TITLE
Minor fix on string #190 (proposal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ class SFDashboard():
 
 #### Generate the pd_options
 
-The best way to generate the pd_options for a PixieDust visualization is to:
+The best way to generate the ``pd_options`` for a PixieDust visualization is to:
 1.  Call ``display()`` on a new cell
 2.  Graphically select the options for your chart
 3.  Select ``View/Cell Toobar/Edit metadata`` menu
@@ -195,7 +195,7 @@ The best way to generate the pd_options for a PixieDust visualization is to:
 
 ![](doc/source/images/pixieEditMetadata.png)
 
-To conform to the pd_options notation, we need to transform the PixieDust JSON metadata into an attribute string with the following format: ```“key1=value1;key2=value2;…”```
+To conform to the ``pd_options`` notation, we need to transform the PixieDust JSON metadata into an attribute string with the following format: ```“key1=value1;key2=value2;…”```
 
 To make it easier, we use the a simple Python transform function:
 ```

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The best way to generate the ``pd_options`` for a PixieDust visualization is to:
 
 To conform to the ``pd_options`` notation, we need to transform the PixieDust JSON metadata into an attribute string with the following format: ```“key1=value1;key2=value2;…”```
 
-To make it easier, we use the a simple Python transform function:
+To make it easier, we use a simple Python transform function:
 ```
 def formatOptions(self, options):
     return ';'.join(["{}={}".format(k,v) for (k, v) in iteritems(options)])


### PR DESCRIPTION
It is ok on string #200: (...) we use the a simple Python transform (...) I wonder: "the `a` simple Python" is right?